### PR TITLE
Included a test suite to look for the toString, equals and hashcode f…

### DIFF
--- a/src/main/java/Lab/Model/House.java
+++ b/src/main/java/Lab/Model/House.java
@@ -1,5 +1,7 @@
 package Lab.Model;
 
+import lombok.*;
+
 /**
  * Lombok is a took that can automatically generate boilerplate code such as ToString, Equals, HashCode, Constructors,
  * and all the needed getters/setters at runtime using annotations. Lombok is not part of Spring, but will be quite

--- a/src/test/java/HouseTestSuite.java
+++ b/src/test/java/HouseTestSuite.java
@@ -1,0 +1,51 @@
+import Lab.Model.House;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class HouseTestSuite {
+
+    /**
+     * Simple test to assure that the equals and hashcode implementations have been override to work with
+     * instances of the HouseClass
+     */
+    @Test
+    public void testEqualsAndHashCodeMethods(){
+        House testHouse1 = new House();
+        testHouse1.id = 10;
+        testHouse1.address = "123 pennsylvania street";
+        testHouse1.bedrooms = 4;
+        testHouse1.bathrooms = 3;
+        testHouse1.squareFeet = 2400;
+
+        House testHouse2 = new House();
+        testHouse2.id = 10;
+        testHouse2.address = "123 pennsylvania street";
+        testHouse2.bedrooms = 4;
+        testHouse2.bathrooms = 3;
+        testHouse2.squareFeet = 2400;
+
+        Assertions.assertEquals(testHouse1, testHouse2);
+        Assertions.assertTrue(testHouse1.hashCode() == testHouse2.hashCode());
+    }
+
+    /**
+     * Simple test to assure that the toString implementations have been override to work with
+     * instances of the HouseClass
+     */
+    @Test
+    public void testToStringMethod(){
+        House testHouse = new House();
+        testHouse.id = 10;
+        testHouse.address = "123 pennsylvania street";
+        testHouse.bedrooms = 4;
+        testHouse.bathrooms = 3;
+        testHouse.squareFeet = 2400;
+
+        boolean isToStringImplemented = testHouse.toString().contains("pennsylvania");
+
+        Assertions.assertTrue(isToStringImplemented);
+    }
+
+}


### PR DESCRIPTION
…unctionality if implemented. Lomboks retention policy is set to SOURCE, unfortnuately not able to use reflection to check for annotations.